### PR TITLE
Tweak for Fluentd v0.14's compatible layer

### DIFF
--- a/fluent-plugin-fortigate-log-parser.gemspec
+++ b/fluent-plugin-fortigate-log-parser.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fluentd"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "test-unit", "~> 3.2"
 end

--- a/fluent-plugin-fortigate-log-parser.gemspec
+++ b/fluent-plugin-fortigate-log-parser.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd"
+  spec.add_dependency "fluentd", ">= 0.12.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit", "~> 3.2"

--- a/lib/fluent/plugin/out_fortigate_log_parser.rb
+++ b/lib/fluent/plugin/out_fortigate_log_parser.rb
@@ -79,7 +79,7 @@ module Fluent
 
       es.each do |time, record|
         time, record = parse(record)
-        Engine.emit(tag, time, record)
+        router.emit(tag, time, record)
       end
 
       chain.next


### PR DESCRIPTION
I think that this plugin should work with Fluentd v0.14 on compatible layer.
This plugin does not depends on test-unit for development.
And the biggest issue is using `Engine.emit`.
It causes raising exception at runtime because Fluentd v0.14 treats it as a bug.